### PR TITLE
[typo] Fix typo in workflow name

### DIFF
--- a/.github/workflows/accessibility-linter.yml
+++ b/.github/workflows/accessibility-linter.yml
@@ -1,4 +1,4 @@
-name: Accessinbility Lint
+name: Accessibility Lint
 
 on: [pull_request]
 


### PR DESCRIPTION
_Bonus:_ Today I learned about [approving workflow runs from public forks](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks). ☺️ 